### PR TITLE
feat: implementa repository/service e validação de CPF e e-mail

### DIFF
--- a/src/main/java/com/the_real_ones/model/Servidor.java
+++ b/src/main/java/com/the_real_ones/model/Servidor.java
@@ -2,6 +2,14 @@ package com.the_real_ones.model;
 
 public class Servidor {
 
+    public enum Sexo {
+        HOMEM_CIS,
+        MULHER_CIS,
+        HOMEM_TRANS,
+        MULHER_TRANS,
+        OUTRO
+    }
+
     // Atributos obrigatórios
     private String nomeCompleto = "";
     private String cpf = "";
@@ -12,7 +20,7 @@ public class Servidor {
 
     // Atributos opcionais
     private String nomeSocial = "";
-    private String[] sexo = new String[]{"Homem-cis", "Mulher-cis", "Homem-trans", "Mulher-trans", "Outro"};
+    private Sexo sexo;
     private String URLLattes = "";
     private String telefone = "";
 
@@ -25,6 +33,8 @@ public class Servidor {
         this.titulacao = titulacao;
     }
 
+
+
     public String getNomeCompleto() {
         return nomeCompleto;
     }
@@ -35,10 +45,6 @@ public class Servidor {
 
     public String getCpf() {
         return cpf;
-    }
-
-    public void setCpf(String cpf) {
-        this.cpf = cpf;
     }
 
     public String getCampus() {
@@ -81,8 +87,12 @@ public class Servidor {
         this.nomeSocial = nomeSocial;
     }
 
-    public String[] getSexo() {
+    public Sexo getSexo() {
         return sexo;
+    }
+
+    public void setSexo(Sexo sexo) {
+        this.sexo = sexo;
     }
 
     public String getURLLattes() {

--- a/src/main/java/com/the_real_ones/repository/ServidorRepository.java
+++ b/src/main/java/com/the_real_ones/repository/ServidorRepository.java
@@ -1,0 +1,67 @@
+package com.the_real_ones.repository;
+
+import com.the_real_ones.model.Servidor;
+
+import java.util.ArrayList;
+
+public class ServidorRepository {
+
+    private final ArrayList<Servidor> servidores = new ArrayList<>();
+
+    public void create(Servidor s) {
+        servidores.add(s);
+    }
+
+    public Servidor readByCpf(String cpf) {
+        for(Servidor s : servidores){
+            if(s.getCpf().equals(cpf)) {
+                return s;
+            }
+        }
+        return null;
+    }
+
+    public void update(Servidor s) {
+        for(Servidor serv : servidores) {
+            if(serv.getCpf().equals(s.getCpf())) {
+                serv.setNomeCompleto(s.getNomeCompleto());
+                serv.setEmailInstitucional(s.getEmailInstitucional());
+                serv.setCampus(s.getCampus());
+                serv.setAreaFormacao(s.getAreaFormacao());
+                serv.setTitulacao(s.getTitulacao());
+                serv.setNomeSocial(s.getNomeSocial());
+                serv.setSexo(s.getSexo());
+                serv.setURLLattes(s.getURLLattes());
+                serv.setTelefone(s.getTelefone());
+
+                return;
+            }
+        }
+    }
+
+    public void delete(Servidor s) {
+        servidores.remove(s);
+    }
+
+    public ArrayList<Servidor> readAll() {
+        return  new ArrayList<>(servidores);
+    }
+
+    public boolean existsByEmail(String email) {
+        for(Servidor s : servidores) {
+            if(s.getEmailInstitucional().equals(email)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean existsByCpf(String cpf) {
+        for(Servidor s : servidores) {
+            if(s.getCpf().equals(cpf)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/the_real_ones/service/ServidorService.java
+++ b/src/main/java/com/the_real_ones/service/ServidorService.java
@@ -1,0 +1,26 @@
+package com.the_real_ones.service;
+
+import com.the_real_ones.model.Servidor;
+import com.the_real_ones.repository.ServidorRepository;
+
+public class ServidorService {
+
+    private ServidorRepository repository;
+
+    public ServidorService(ServidorRepository repository) {
+        this.repository = repository;
+    }
+
+    public boolean cadastrarServidor(Servidor servidor) {
+
+        if(repository.existsByCpf(servidor.getCpf())) {
+            throw new IllegalArgumentException("Servidor já existente, CPF já cadastrado");
+        }
+        if(repository.existsByEmail(servidor.getEmailInstitucional())) {
+            throw new IllegalArgumentException("E-mail já cadastrado");
+        }
+
+        repository.create(servidor);
+        return true;
+    }
+}


### PR DESCRIPTION
# Implementação da entidade Servidor e regras de cadastro

## Alterações realizadas

* Refatoração da entidade `Servidor`
* Substituição do atributo `sexo` por `enum Sexo`
* Remoção do setter de CPF para manter imutabilidade do identificador
* Criação da camada `ServidorRepository`
* Criação da camada `ServidorService`
* Implementação das operações básicas de persistência em memória
* Implementação das validações de unicidade:
  * CPF único
  * E-mail único
* Refatoração dos métodos de busca para nomenclatura explícita (`readByCpf`)
* Padronização dos métodos `existsByCpf` e `existsByEmail`

## Objetivo

Estruturar a base da entidade `Servidor` seguindo separação de responsabilidades entre:

* Model
* Repository
* Service

Além de implementar as regras de negócio exigidas para cadastro de servidores.
